### PR TITLE
Update to Inquirer

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -4,7 +4,7 @@ var fork = require('child_process').fork;
 var Configstore = require('configstore');
 var colors = require('colors');
 var _ = require('lodash');
-var prompt = require('prompt');
+var prompt = require('inquirer');
 
 
 function Insight (options) {
@@ -75,22 +75,14 @@ Insight.prototype.askPermission = function (msg, cb) {
 	var defaultMsg = 'May ' + this.packageName.cyan + ' anonymously report usage statistics to improve the tool over time?';
 
 	cb = cb || function () {};
-	console.log(msg || defaultMsg);
 
-	prompt.message = '[' + '?'.green + ']';
-	prompt.delimiter = ' ';
-	prompt.start();
-	prompt.get([{
+	prompt({
+    type: 'confirm',
 		name: 'optIn',
-		message: '[Y/n]:',
-		default: 'Y',
-		validator: /^[yn]{1}/i,
-		empty: false
-	}], function (err, result) {
-		if (err) {
-			return cb(err);
-		}
-		this.optOut = /n/i.test(result.optIn);
+		message: msg || defaultMsg,
+		default: true
+	}, function (result) {
+		this.optOut = !result.optIn;
 		cb(null, this.optOut);
 	}.bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "configstore": "~0.1.0",
     "async": "~0.1.22",
     "lodash": "~1.0.0-rc.2",
-    "prompt": "~0.2.8"
+    "inquirer": "~0.1.9"
   },
   "devDependencies": {
     "mocha": "~1.7.4"


### PR DESCRIPTION
Fixes https://github.com/yeoman/yeoman/issues/1104

The `prompt` dependency has a dependency on `utile`, which has changed their API, causing an error:

```
/usr/local/lib/node_modules/yo/node_modules/insight/node_modules/prompt/lib/prompt.js:12
capitalize = utile.inflect.capitalize,
^
TypeError: Cannot read property 'capitalize' of undefined
at Object. (/usr/local/lib/node_modules/yo/node_modules/insight/node_modules/prompt/lib/prompt.js:12:31)
at Module._compile (module.js:456:26)
at Object.Module._extensions..js (module.js:474:10)
at Module.load (module.js:356:32)
at Function.Module._load (module.js:312:12)
at Module.require (module.js:364:17)
at require (module.js:380:17)
at Object. (/usr/local/lib/node_modules/yo/node_modules/insight/lib/insight.js:7:14)
at Module._compile (module.js:456:26)
at Object.Module._extensions..js (module.js:474:10)
```
