### PR TITLE
Change colors dependency to chalk

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -2,7 +2,7 @@
 var path = require('path');
 var fork = require('child_process').fork;
 var Configstore = require('configstore');
-var colors = require('colors');
+var chalk = require('chalk');
 var _ = require('lodash');
 var inquirer = require('inquirer');
 var providers = require('./providers');
@@ -82,7 +82,7 @@ Insight.prototype.track = function () {
 };
 
 Insight.prototype.askPermission = function (msg, cb) {
-	var defaultMsg = 'May ' + this.packageName.cyan + ' anonymously report usage statistics to improve the tool over time?';
+	var defaultMsg = 'May ' + chalk.cyan(this.packageName) + ' anonymously report usage statistics to improve the tool over time?';
 
 	cb = cb || function () {};
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "node node_modules/mocha/bin/mocha test/test-*.js"
   },
   "dependencies": {
-    "colors": "~0.6.0-1",
+    "chalk": "~0.2.0",
     "request": "~2.26.0",
     "configstore": "~0.1.0",
     "async": "~0.2.9",


### PR DESCRIPTION
From chalk readme:

> colors.js is currently the most popular string styling module, but it has serious deficiencies like extending String.prototype which causes all kinds of problems. Although there are other ones, they either do too much or not enough.
