### PR TITLE
Add option for custom config store

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -19,7 +19,7 @@ function Insight (options) {
 	this.trackingProvider = options.trackingProvider || 'google';
 	this.packageName = options.packageName || this.packageFile.name;
 	this.packageVersion = options.packageVersion || this.packageFile.version;
-	this.config = new Configstore('insight-' + this.packageName, {
+	this.config = options.config || new Configstore('insight-' + this.packageName, {
 		clientId: options.clientId || Math.floor(Date.now() * Math.random())
 	});
 	this._queue = {};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "inquirer": "~0.2.4"
   },
   "devDependencies": {
-    "mocha": "~1.12.0"
+    "mocha": "~1.12.0",
+    "sinon": "~1.7.3"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,18 @@ Default: Inferred from `packageFile`
 Used instead of inferring it from `packageFile`  
 Requires you to also specify `packageName`
 
+#### config
+
+Type: `object`  
+Default: An instance of [`configstore`](https://github.com/yeoman/configstore)
+
+If you want to use your own configuration mechanism instead of the default
+`configstore`-based one, you can provide an object that has to implement two
+synchronous methods:
+
+- `get(key)`
+- `set(key, value)`
+
 
 ### Instance methods
 

--- a/test/test-insight.js
+++ b/test/test-insight.js
@@ -1,6 +1,7 @@
-/*global describe, it */
+/*global describe, it, beforeEach */
 'use strict';
 var assert = require('assert');
+var sinon = require('sinon');
 var Insight = require('../lib/insight');
 var _ = require('lodash');
 
@@ -64,5 +65,34 @@ describe('providers', function() {
 			assert.equal(cookie.name, 'yandexuid');
 			assert.equal(cookie.value, insight.clientId);
 		});
+	});
+});
+
+describe('config providers', function () {
+	beforeEach(function () {
+		var pkg = 'yeoman';
+		var ver = '0.0.0';
+
+		this.config = {
+			get: sinon.spy(function () { return true; }),
+			set: sinon.spy()
+		};
+
+		this.insight = new Insight({
+			packageName: pkg,
+			packageVersion: ver,
+			config: this.config
+		});
+	});
+
+	it('should access the config object for reading', function () {
+		assert(this.insight.optOut);
+		assert(this.config.get.called);
+	});
+
+	it('should access the config object for writing', function () {
+		var sentinel = {};
+		this.insight.optOut = sentinel;
+		assert(this.config.set.calledWith('optOut', sentinel));
 	});
 });


### PR DESCRIPTION
Bower wants to keep the opt out settings in the same place as the remaining settings, so it makes sense to allow users to provide their own configuration object.

/ref https://github.com/bower/bower/issues/260
