### PR TITLE
Include config field in payload for child process

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -59,7 +59,8 @@ Insight.prototype._getPayload = function() {
 		packageName: this.packageName,
 		packageVersion: this.packageVersion,
 		trackingCode: this.trackingCode,
-		trackingProvider: this.trackingProvider
+		trackingProvider: this.trackingProvider,
+		config: this.config
 	};
 };
 


### PR DESCRIPTION
I'm not quite sure about passing complex objects between process, but nodejs documentation says [that its ok](http://nodejs.org/api/child_process.html#child_process_example_sending_server_object).
