### PR TITLE
Fix forked process die on windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ Object.defineProperty(Insight.prototype, 'clientId', {
 
 // debounce in case of rapid .track() invocations
 Insight.prototype._save = debounce(function () {
-	var cp = fork(path.join(__dirname, 'push.js'));
+	var cp = fork(path.join(__dirname, 'push.js'), {silent: true});
 	cp.send(this._getPayload());
 	cp.unref();
 	cp.disconnect();


### PR DESCRIPTION
I'm using insight with yeoman generator and google analytics (not important).
On windows, if generator ends before forked (stat) process, it gets killd with main (no analytics send).
Works proerly on linux.

Silent flag fixes problem. On linux it works as before with flag (correctly).