### PR TITLE
Adds optional permission timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ function Insight (options) {
 		clientId: options.clientId || Math.floor(Date.now() * Math.random())
 	});
 	this._queue = {};
+
+	this._permissionTimeout = 30;
 }
 
 Object.defineProperty(Insight.prototype, 'optOut', {
@@ -106,15 +108,28 @@ Insight.prototype.askPermission = function (msg, cb) {
 		return;
 	}
 
-	inquirer.prompt({
+	var prompt = inquirer.prompt({
 		type: 'confirm',
 		name: 'optIn',
 		message: msg || defaultMsg,
 		default: true
 	}, function (result) {
+		// Upon getting an answer, clear the permission timeout
+		clearTimeout(permissionTimeout);
+
 		this.optOut = !result.optIn;
 		cb(null, result.optIn);
 	}.bind(this));
+
+	// Add a 30 sec timeout before giving up on getting an answer
+	var permissionTimeout = setTimeout(function () {
+		// Stop listening for stdin
+		prompt.close();
+
+		// Automatically opt out
+		this.optOut = true;
+		cb(null, false);
+	}, this._permissionTimeout * 1000);
 };
 
 module.exports = Insight;

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ Insight.prototype.askPermission = function (msg, cb) {
 
 	cb = cb || function () {};
 
-	if (!process.stdout.isTTY || process.argv.indexOf('--no-insight') !== -1) {
+	if (!process.stdout.isTTY || process.argv.indexOf('--no-insight') !== -1 || process.env.CI) {
 		setImmediate(cb, null, false);
 		return;
 	}

--- a/test/fixtures/sub-process.js
+++ b/test/fixtures/sub-process.js
@@ -7,6 +7,10 @@ var insight = new Insight({
 	trackingCode: 'GA-1234567-1'
 });
 
+if (process.env.permissionTimeout) {
+    insight._permissionTimeout = process.env.permissionTimeout;
+}
+
 insight.askPermission('', function () {
 	process.exit(145);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -154,4 +154,17 @@ describe('askPermission', function () {
 			done();
 		});
 	});
+
+	it('should skip after timeout', function (done) {
+		var env = JSON.parse(JSON.stringify(process.env));
+		env.permissionTimeout = 0.1;
+
+		var insProcess = spawn('node', [
+			'./test/fixtures/sub-process.js'
+		], {stdio: 'inherit', env: env});
+		insProcess.on('close', function (code) {
+			assert.equal(code, 145);
+			done();
+		});
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,19 @@ describe('askPermission', function () {
 		});
 	});
 
+	it('should skip in CI mode', function (done) {
+		var env = JSON.parse(JSON.stringify(process.env));
+		env.CI = true;
+
+		var insProcess = spawn('node', [
+			'./test/fixtures/sub-process.js'
+		], {stdio: 'inherit', env: env});
+		insProcess.on('close', function (code) {
+			assert.equal(code, 145);
+			done();
+		});
+	});
+
 	it('should skip after timeout', function (done) {
 		var env = JSON.parse(JSON.stringify(process.env));
 		env.permissionTimeout = 0.1;


### PR DESCRIPTION
Adds the option to pass along `permissionTimeout` during init, which will let the permission prompt fall back to opt out after X seconds.