### PR TITLE
Bump minimum supported `node` version to `node@4`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ var fork = require('child_process').fork;
 var osName = require('os-name');
 var Configstore = require('configstore');
 var chalk = require('chalk');
-var assign = require('object-assign');
 var debounce = require('lodash.debounce');
 var inquirer = require('inquirer');
 var uuid = require('uuid');
@@ -73,7 +72,7 @@ Insight.prototype._save = debounce(function () {
 
 Insight.prototype._getPayload = function () {
 	return {
-		queue: assign({}, this._queue),
+		queue: Object.assign({}, this._queue),
 		packageName: this.packageName,
 		packageVersion: this.packageVersion,
 		trackingCode: this.trackingCode,
@@ -142,7 +141,9 @@ Insight.prototype.askPermission = function (msg, cb) {
 		name: 'optIn',
 		message: msg || defaultMsg,
 		default: true
-	}, function (result) {
+	});
+
+	prompt.then(function (result) {
 		// clear the permission timeout upon getting an answer
 		clearTimeout(permissionTimeout);
 
@@ -153,7 +154,7 @@ Insight.prototype.askPermission = function (msg, cb) {
 	// add a 30 sec timeout before giving up on getting an answer
 	permissionTimeout = setTimeout(function () {
 		// stop listening for stdin
-		prompt.close();
+		prompt.ui.close();
 
 		// automatically opt out
 		this.optOut = true;

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -76,12 +76,12 @@ module.exports = {
 
 		var path = payload.path;
 		var qs = {
-			'wmode': 3,
-			'ut': 'noindex',
+			wmode: 3,
+			ut: 'noindex',
 			'page-url': 'http://' + this.packageName + '.insight' + path + '?version=' + this.packageVersion,
 			'browser-info': 'i:' + ts + ':z:0:t:' + path,
 			// cache busting
-			'rn': Date.now()
+			rn: Date.now()
 		};
 
 		var url = 'https://mc.yandex.ru/watch/' + this.trackingCode;

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,7 +1,6 @@
 'use strict';
 var request = require('request');
 var async = require('async');
-var assign = require('object-assign');
 var Insight = require('./');
 
 // Messaged on each debounced track()
@@ -12,7 +11,7 @@ process.on('message', function (msg) {
 	var config = insight.config;
 	var q = config.get('queue') || {};
 
-	assign(q, msg.queue);
+	Object.assign(q, msg.queue);
 	config.del('queue');
 
 	async.forEachSeries(Object.keys(q), function (el, cb) {
@@ -31,7 +30,7 @@ process.on('message', function (msg) {
 	}, function (err) {
 		if (err) {
 			var q2 = config.get('queue') || {};
-			assign(q2, q);
+			Object.assign(q2, q);
 			config.set('queue', q2);
 		}
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "lib",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && mocha --timeout 20000 --reporter spec test/test.js"
@@ -31,13 +31,12 @@
     "metrica"
   ],
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "^2.1.4",
     "chalk": "^1.0.0",
-    "configstore": "^1.0.0",
-    "inquirer": "^0.10.0",
-    "lodash.debounce": "^3.0.1",
-    "object-assign": "^4.0.1",
-    "os-name": "^1.0.0",
+    "configstore": "^2.1.0",
+    "inquirer": "^3.0.1",
+    "lodash.debounce": "^4.0.8",
+    "os-name": "^2.0.1",
     "request": "^2.74.0",
     "tough-cookie": "^2.0.0",
     "uuid": "^3.0.0"
@@ -46,6 +45,6 @@
     "mocha": "*",
     "object-values": "^1.0.0",
     "sinon": "*",
-    "xo": "^0.16.0"
+    "xo": "^0.17.1"
   }
 }


### PR DESCRIPTION
Also update dependencies and drop ponyfills.
Would you like to postpone this until a version of `configstore` with https://github.com/yeoman/configstore/pull/49 merged is published?