### PR TITLE
Immediate execution of debounce function in _save

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ class Insight {
 			cp.disconnect();
 
 			this._queue = {};
-		}, 100);
+		}, 100)();
 	}
 	_getPayload() {
 		return {


### PR DESCRIPTION
debounce function in the save function is not being executed in the ES2015 rewrite. So, payload not being sent to the child process