### PR TITLE
Batch calls from the same event loop run + don't delay first send

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const fork = require('child_process').fork;
+const childProcess = require('child_process');
 const osName = require('os-name');
 const Configstore = require('configstore');
 const chalk = require('chalk');
@@ -8,6 +8,8 @@ const debounce = require('lodash.debounce');
 const inquirer = require('inquirer');
 const uuid = require('uuid');
 const providers = require('./providers');
+
+const DEBOUNCE_MILLIS = 100;
 
 class Insight {
 	constructor(options) {
@@ -40,6 +42,7 @@ class Insight {
 		});
 		this._queue = {};
 		this._permissionTimeout = 30;
+		this._debouncedSend = debounce(this._send, DEBOUNCE_MILLIS, {leading: true});
 	}
 	get optOut() {
 		return this.config.get('optOut');
@@ -54,15 +57,24 @@ class Insight {
 		this.config.set('clientId', val);
 	}
 	_save() {
-		// Debounce in case of rapid .track() invocations
-		debounce(() => {
-			const cp = fork(path.join(__dirname, 'push.js'), {silent: true});
-			cp.send(this._getPayload());
-			cp.unref();
-			cp.disconnect();
-
-			this._queue = {};
-		}, 100)();
+		setImmediate(() => {
+			this._debouncedSend();
+		});
+	}
+	_send() {
+		const pending = Object.keys(this._queue).length;
+		if (pending === 0) {
+			return;
+		}
+		this._fork(this._getPayload());
+		this._queue = {};
+	}
+	_fork(payload) {
+		// Extracted to a method so it can be easily mocked
+		const cp = childProcess.fork(path.join(__dirname, 'push.js'), {silent: true});
+		cp.send(payload);
+		cp.unref();
+		cp.disconnect();
 	}
 	_getPayload() {
 		return {

--- a/test/insight.js
+++ b/test/insight.js
@@ -1,21 +1,7 @@
 import objectValues from 'object-values';
+import sinon from 'sinon';
 import test from 'ava';
 import Insight from '../lib';
-
-const insight = new Insight({
-	trackingCode: 'xxx',
-	packageName: 'yeoman',
-	packageVersion: '0.0.0'
-});
-
-insight.optOut = false;
-
-test('put tracked path in queue', t => {
-	Insight.prototype._save = function () {
-		t.is('/test', objectValues(this._queue)[0].path);
-	};
-	insight.track('test');
-});
 
 test('throw exception when trackingCode or packageName is not provided', t => {
 	/* eslint-disable no-new */
@@ -32,3 +18,93 @@ test('throw exception when trackingCode or packageName is not provided', t => {
 	}, Error);
 	/* eslint-enable no-new */
 });
+
+test.cb('forks a new tracker right after track()', t => {
+	const insight = newInsight();
+	insight.track('test');
+	setImmediate(() => {
+		t.deepEqual(forkedCalls(insight), [
+			// A single fork with a single path
+			['/test']
+		]);
+		t.end();
+	});
+});
+
+test.cb('only forks once if many pages are tracked in the same event loop run', t => {
+	const insight = newInsight();
+	insight.track('foo');
+	insight.track('bar');
+	setImmediate(() => {
+		t.deepEqual(forkedCalls(insight), [
+			// A single fork with both paths
+			['/foo', '/bar']
+		]);
+		t.end();
+	});
+});
+
+test.cb('debounces forking every 100 millis (close together)', t => {
+	const insight = newInsight();
+	setTimeout(() => insight.track('0'), 0);
+	setTimeout(() => insight.track('50'), 50);
+	setTimeout(() => insight.track('100'), 100);
+	setTimeout(() => insight.track('150'), 150);
+	setTimeout(() => insight.track('200'), 200);
+	setTimeout(() => {
+		t.deepEqual(forkedCalls(insight), [
+			// The first one is sent straight away because of the leading debounce
+			['/0'],
+			// The others are grouped together because they're all < 100ms apart
+			['/50', '/100', '/150', '/200']
+		]);
+		t.end();
+	}, 1000);
+});
+
+test.cb('debounces forking every 100 millis (far apart)', t => {
+	const insight = newInsight();
+	setTimeout(() => insight.track('0'), 0);
+	setTimeout(() => insight.track('50'), 50);
+	setTimeout(() => insight.track('100'), 100);
+	setTimeout(() => insight.track('150'), 150);
+	setTimeout(() => insight.track('300'), 300);
+	setTimeout(() => insight.track('350'), 350);
+	setTimeout(() => {
+		t.deepEqual(forkedCalls(insight), [
+			// Leading call
+			['/0'],
+			// Sent together since there is an empty 100ms window afterwards
+			['/50', '/100', '/150'],
+			// Sent on its own because it's a new leading debounce
+			['/300'],
+			// Finally, the last one is sent
+			['/350']
+		]);
+		t.end();
+	}, 1000);
+});
+
+// Return a valid insight instance which doesn't actually send analytics (mocked)
+function newInsight() {
+	const insight = new Insight({
+		trackingCode: 'xxx',
+		packageName: 'yeoman',
+		packageVersion: '0.0.0'
+	});
+	insight.optOut = false;
+	insight._fork = sinon.stub();
+	return insight;
+}
+
+// Returns all forked calls, and which paths were tracked in that fork
+// This is handy to get a view of all forks at once instead of debugging 1 by 1
+// [
+//   ['/one', 'two'],       // first call tracked 2 paths
+//   ['/three', 'four'],    // second call tracked 2 more paths
+// ]
+function forkedCalls(insight) {
+	return insight._fork.args.map(callArgs => {
+		return objectValues(callArgs[0].queue).map(q => q.path);
+	});
+}


### PR DESCRIPTION
Hi @sindresorhus and @SBoudrias, thanks for this very useful package! As discussed in #58:

- this PR still debounces calls made within a 100ms window, but doesn't delay the first send. This fixes the edge case where a program calls `track()` and exits almost immediately (before the initial 100ms delay). This is done using `debounce({leading: true})` as suggested.
- it also batches all calls made within the same execution flow. This means only 1 fork / HTTP request is made when `insight.track()` is called 5 times in the same function. That's done with a simple `setImmediate` to only send once the current execution is finished.

It would be great to have unit tests around it, which would require mocking `child_process.fork` for example. There are currently no tests for that core logic, so maybe for another PR?
