### PR TITLE
Update xo & ava to fix tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,6 +75,7 @@ class Insight {
 		if (pending === 0) {
 			return;
 		}
+
 		this._fork(this._getPayload());
 		this._queue = {};
 	}
@@ -97,16 +98,16 @@ class Insight {
 		};
 	}
 
-	_getRequestObj() {
-		return providers[this.trackingProvider].apply(this, arguments);
+	_getRequestObj(...args) {
+		return providers[this.trackingProvider].apply(this, args);
 	}
 
-	track() {
+	track(...args) {
 		if (this.optOut) {
 			return;
 		}
 
-		const path = '/' + [].map.call(arguments, el => String(el).trim().replace(/ /, '-')).join('/');
+		const path = '/' + args.map(el => String(el).trim().replace(/ /, '-')).join('/');
 
 		// Timestamp isn't unique enough since it can end up with duplicate entries
 		this._queue[`${Date.now()} ${uuid.v4()}`] = {

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -76,7 +76,7 @@ module.exports = {
 			.replace(/[-:T]/g, '')
 			.replace(/\..*$/, '');
 
-		const path = payload.path;
+		const {path} = payload;
 		const qs = {
 			wmode: 3,
 			ut: 'noindex',

--- a/lib/push.js
+++ b/lib/push.js
@@ -8,7 +8,7 @@ const Insight = require('.');
 // If it fails, it will save everything again
 process.on('message', msg => {
 	const insight = new Insight(msg);
-	const config = insight.config;
+	const {config} = insight;
 	const q = config.get('queue') || {};
 
 	Object.assign(q, msg.queue);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
 	"scripts": {
 		"test": "xo && ava --timeout=20s"
 	},
+	"xo": {
+		"ignores": [
+			"test/fixtures"
+		]
+	},
 	"files": [
 		"lib"
 	],
@@ -45,6 +50,6 @@
 		"execa": "^0.10.0",
 		"object-values": "^1.0.0",
 		"sinon": "^4.1.1",
-		"xo": "^0.20.3"
+		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"uuid": "^3.0.0"
 	},
 	"devDependencies": {
-		"ava": "*",
+		"ava": "^1.4.1",
 		"execa": "^0.10.0",
 		"object-values": "^1.0.0",
 		"sinon": "^4.1.1",

--- a/test/ask-permission.js
+++ b/test/ask-permission.js
@@ -2,12 +2,12 @@ import execa from 'execa';
 import test from 'ava';
 
 test('skip in TTY mode', async t => {
-	const err = await t.throws(execa('node', ['./test/fixtures/sub-process.js']));
+	const err = await t.throwsAsync(execa('node', ['./test/fixtures/sub-process.js']));
 	t.is(err.code, 145);
 });
 
 test('skip when using the --no-insight flag', async t => {
-	const err = await t.throws(execa('node', ['./test/fixtures/sub-process.js', '--no-insight'], {stdio: 'inherit'}));
+	const err = await t.throwsAsync(execa('node', ['./test/fixtures/sub-process.js', '--no-insight'], {stdio: 'inherit'}));
 	t.is(err.code, 145);
 });
 
@@ -15,7 +15,7 @@ test('skip in CI mode', async t => {
 	const {CI} = process.env;
 	process.env.CI = true;
 
-	const err = await t.throws(execa('node', ['./test/fixtures/sub-process.js'], {stdio: 'inherit'}));
+	const err = await t.throwsAsync(execa('node', ['./test/fixtures/sub-process.js'], {stdio: 'inherit'}));
 	t.is(err.code, 145);
 
 	process.env.CI = CI;
@@ -28,7 +28,7 @@ test('skip after timeout', async t => {
 	process.env.CI = true;
 	process.env.permissionTimeout = 0.1;
 
-	const err = await t.throws(execa('node', ['./test/fixtures/sub-process.js'], {stdio: 'inherit'}));
+	const err = await t.throwsAsync(execa('node', ['./test/fixtures/sub-process.js'], {stdio: 'inherit'}));
 	t.is(err.code, 145);
 
 	process.env.CI = CI;

--- a/test/ask-permission.js
+++ b/test/ask-permission.js
@@ -12,7 +12,7 @@ test('skip when using the --no-insight flag', async t => {
 });
 
 test('skip in CI mode', async t => {
-	const CI = process.env.CI;
+	const {CI} = process.env;
 	process.env.CI = true;
 
 	const err = await t.throws(execa('node', ['./test/fixtures/sub-process.js'], {stdio: 'inherit'}));
@@ -22,8 +22,8 @@ test('skip in CI mode', async t => {
 });
 
 test('skip after timeout', async t => {
-	const CI = process.env.CI;
-	const permissionTimeout = process.env.permissionTimeout;
+	const {CI} = process.env;
+	const {permissionTimeout} = process.env;
 
 	process.env.CI = true;
 	process.env.permissionTimeout = 0.1;


### PR DESCRIPTION
On a fresh install, the tests are currently failing because of breaking changes in `ava`. This PR updates the tests to work with `ava@1` and also updates `xo` so that new `ava` API is correctly recognized.