### PR TITLE
Make debouncing tests reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 	"devDependencies": {
 		"ava": "^1.4.1",
 		"execa": "^0.10.0",
-		"object-values": "^1.0.0",
 		"sinon": "^4.1.1",
 		"xo": "^0.24.0"
 	}

--- a/test/insight.js
+++ b/test/insight.js
@@ -1,4 +1,3 @@
-import objectValues from 'object-values';
 import sinon from 'sinon';
 import test from 'ava';
 import Insight from '../lib';
@@ -19,92 +18,80 @@ test('throw exception when trackingCode or packageName is not provided', t => {
 	/* eslint-enable no-new */
 });
 
-test.cb('forks a new tracker right after track()', t => {
+test.cb('sends right after calling track()', t => {
 	const insight = newInsight();
 	insight.track('test');
 	setImmediate(() => {
-		t.deepEqual(forkedCalls(insight), [
-			// A single fork with a single path
-			['/test']
-		]);
+		t.is(insight._send.callCount, 1);
 		t.end();
 	});
 });
 
-test.cb('only forks once if many pages are tracked in the same event loop run', t => {
+test.cb('only sends once if many pages are tracked in the same event loop run', t => {
 	const insight = newInsight();
 	insight.track('foo');
 	insight.track('bar');
 	setImmediate(() => {
-		t.deepEqual(forkedCalls(insight), [
-			// A single fork with both paths
-			['/foo', '/bar']
-		]);
+		t.is(insight._send.callCount, 1);
 		t.end();
 	});
 });
 
-test.cb('debounces forking every 100 millis (close together)', t => {
+test.cb('debounces sending every 100 millis (close together)', t => {
 	const insight = newInsight();
+
+	// The first one is sent straight away because of the leading debounce
 	setTimeout(() => insight.track('0'), 0);
+
+	// The others are grouped together because they're all < 100ms apart
 	setTimeout(() => insight.track('50'), 50);
 	setTimeout(() => insight.track('100'), 100);
 	setTimeout(() => insight.track('150'), 150);
 	setTimeout(() => insight.track('200'), 200);
+
 	setTimeout(() => {
-		t.deepEqual(forkedCalls(insight), [
-			// The first one is sent straight away because of the leading debounce
-			['/0'],
-			// The others are grouped together because they're all < 100ms apart
-			['/50', '/100', '/150', '/200']
-		]);
+		t.is(insight._send.callCount, 2);
 		t.end();
 	}, 1000);
 });
 
-test.cb('debounces forking every 100 millis (far apart)', t => {
+test.cb('debounces sending every 100 millis (far apart)', t => {
 	const insight = newInsight();
+
+	// Leading call
 	setTimeout(() => insight.track('0'), 0);
+
+	// Sent together since there is an empty 100ms window afterwards
 	setTimeout(() => insight.track('50'), 50);
 	setTimeout(() => insight.track('100'), 100);
 	setTimeout(() => insight.track('150'), 150);
+
+	// Sent on its own because it's a new leading debounce
 	setTimeout(() => insight.track('300'), 300);
+
+	// Finally, the last one is sent
 	setTimeout(() => insight.track('350'), 350);
+
 	setTimeout(() => {
-		t.deepEqual(forkedCalls(insight), [
-			// Leading call
-			['/0'],
-			// Sent together since there is an empty 100ms window afterwards
-			['/50', '/100', '/150'],
-			// Sent on its own because it's a new leading debounce
-			['/300'],
-			// Finally, the last one is sent
-			['/350']
-		]);
+		t.is(insight._send.callCount, 4);
 		t.end();
 	}, 1000);
 });
 
 // Return a valid insight instance which doesn't actually send analytics (mocked)
 function newInsight() {
-	const insight = new Insight({
+	// _debouncedSend wraps _send during construction, so we have to replace
+	// Insight.prototype._send with a stub. However, if we do that on Insight,
+	// then tests executed in parallel will share the same stub. That's why we
+	// create a new class for every caller.
+	class StubbedInsight extends Insight {}
+	StubbedInsight.prototype._send = sinon.stub();
+
+	const insight = new StubbedInsight({
 		trackingCode: 'xxx',
 		packageName: 'yeoman',
 		packageVersion: '0.0.0'
 	});
 	insight.optOut = false;
-	insight._fork = sinon.stub();
 	return insight;
-}
-
-// Returns all forked calls, and which paths were tracked in that fork
-// This is handy to get a view of all forks at once instead of debugging 1 by 1
-// [
-//   ['/one', 'two'],       // first call tracked 2 paths
-//   ['/three', 'four'],    // second call tracked 2 more paths
-// ]
-function forkedCalls(insight) {
-	return insight._fork.args.map(callArgs => {
-		return objectValues(callArgs[0].queue).map(q => q.path);
-	});
 }


### PR DESCRIPTION
Previously, these tests stubbed the `_fork` method of the instance under
test. The problem was that this method was only ever called using
`setImmediate`. That made it difficult to reliably test the timing
sensible behavior that was to be tested by these tests.

That's why the new tests stub the `_send` method one step higher in the
stack. The contents of the batches is not checked anymore. Instead
it is only verified that the expected number of batches have been sent.

Fixes #64