### PR TITLE
Update all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,21 +35,21 @@
 		"metrica"
 	],
 	"dependencies": {
-		"async": "^2.1.4",
-		"chalk": "^2.3.0",
-		"conf": "^1.3.1",
-		"inquirer": "^5.0.0",
+		"async": "^2.6.2",
+		"chalk": "^2.4.2",
+		"conf": "^2.2.0",
+		"inquirer": "^6.3.1",
 		"lodash.debounce": "^4.0.8",
-		"os-name": "^2.0.1",
-		"request": "^2.74.0",
-		"tough-cookie": "^2.0.0",
-		"uuid": "^3.0.0"
+		"os-name": "^3.1.0",
+		"request": "^2.88.0",
+		"tough-cookie": "^3.0.1",
+		"uuid": "^3.3.2"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
-		"execa": "^0.10.0",
-		"object-values": "^1.0.0",
-		"sinon": "^4.1.1",
+		"execa": "^1.0.0",
+		"object-values": "^2.0.0",
+		"sinon": "^7.3.1",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
As promised, @SBoudrias.

`conf` remained at 2.x instead of latest to preserve Node 6 compatibility. All updated packages remain Node 6 compatible so this can go into a patch level release.

The primary motivation was to profit from reduced loading times for latest `inquirer`. It made less difference than expected though. Partial loading of `rxjs` still takes quite some time.