### PR TITLE
Revert incompatible update to conf@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"async": "^2.6.2",
 		"chalk": "^2.4.2",
-		"conf": "^2.2.0",
+		"conf": "^1.4.0",
 		"inquirer": "^6.3.1",
 		"lodash.debounce": "^4.0.8",
 		"os-name": "^3.1.0",


### PR DESCRIPTION
Starting from v2.0.0, `conf` throws errors when trying to set a key to `undefined` (see https://github.com/sindresorhus/conf/issues/25).

However, users of `insight` rely on `optOut === undefined` representing an undecided state and apparently on being able to reset `insight` to that state by doing`optOut = undefined`.

To fix this, `conf` is reverted to v1.

Fixes #68