### PR TITLE
Bump `uuid` to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"os-name": "^4.0.1",
 		"request": "^2.88.0",
 		"tough-cookie": "^4.0.0",
-		"uuid": "^3.3.2"
+		"uuid": "^8.3.2"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
Simple version bump

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```