### PR TITLE
Replace `request` with `got`

### DIFF
--- a/lib/providers.js
+++ b/lib/providers.js
@@ -69,7 +69,7 @@ module.exports = {
 	},
 	// Yandex.Metrica - https://metrica.yandex.com
 	yandex(id, payload) {
-		const request = require('request');
+		const {CookieJar, Cookie} = require('tough-cookie');
 
 		const ts = new Date(Number.parseInt(id, 10))
 			.toISOString()
@@ -89,16 +89,16 @@ module.exports = {
 		const url = `https://mc.yandex.ru/watch/${this.trackingCode}`;
 
 		// Set custom cookie using tough-cookie
-		const _jar = request.jar();
+		const _jar = new CookieJar();
 		const cookieString = `name=yandexuid; value=${this.clientId}; path=/;`;
-		const cookie = request.cookie(cookieString);
+		const cookie = Cookie.parse(cookieString);
 		_jar.setCookie(cookie, url);
 
 		return {
 			url,
 			method: 'GET',
-			qs,
-			jar: _jar,
+			searchParams: qs,
+			cookieJar: _jar,
 		};
 	},
 };

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,5 +1,5 @@
 'use strict';
-const request = require('request');
+const got = require('got');
 const async = require('async');
 const Insight = require('.');
 
@@ -19,14 +19,14 @@ process.on('message', message => {
 		const id = parts[0];
 		const payload = q[element];
 
-		request(insight._getRequestObj(id, payload), error => {
-			if (error) {
-				cb(error);
-				return;
-			}
-
+		try {
+			got(insight._getRequestObj(id, payload));
+		} catch (error) {
+			cb(error);
+			return;
+		} finally {
 			cb();
-		});
+		}
 	}, error => {
 		if (error) {
 			const q2 = config.get('queue') || {};

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"inquirer": "^6.3.1",
 		"lodash.debounce": "^4.0.8",
 		"os-name": "^4.0.1",
-		"request": "^2.88.0",
+		"got": "^11.8.2",
 		"tough-cookie": "^4.0.0",
 		"uuid": "^8.3.2"
 	},

--- a/test/providers-yandex-metrica.js
+++ b/test/providers-yandex-metrica.js
@@ -18,21 +18,21 @@ const insight = new Insight({
 });
 
 test('form valid request', async t => {
-	const request = require('request');
+	const got = require('got');
 
 	// Test querystrings
 	const requestObject = insight._getRequestObj(ts, pageviewPayload);
-	const _qs = requestObject.qs;
+	const _qs = requestObject.searchParams;
 
 	t.is(_qs['page-url'], `http://${pkg}.insight/test/path?version=${ver}`);
 	t.is(_qs['browser-info'], `i:20130824223344:z:0:t:${pageviewPayload.path}`);
 
 	// Test cookie
-	await request(requestObject);
+	await got(requestObject).catch(() => {});
 
 	// Cookie string looks like:
 	// [{"key":"name","value":"yandexuid",
 	// 	"extensions":["value=80579748502"],"path":"/","creation":...
-	const cookieClientId = requestObject.jar.getCookies(requestObject.url)[0].extensions[0].split('=')[1];
+	const cookieClientId = (await requestObject.cookieJar.getCookies(requestObject.url))[0].extensions[0].split('=')[1];
 	t.is(Number(cookieClientId), Number(insight.clientId));
 });


### PR DESCRIPTION
Fixes #52

Just replaced any use of `request` with a `got` equivalent.

Draft because I can't get it to send any requests in push.js, and given I'm not very experienced with js, any suggestions would be helpful.