### PR TITLE
dep!: replace os-name with systeminformation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,12 @@
 'use strict';
 const path = require('path');
 const childProcess = require('child_process');
-const osName = require('os-name');
 const Conf = require('conf');
 const chalk = require('chalk');
 const debounce = require('lodash.debounce');
 const inquirer = require('inquirer');
 const uuid = require('uuid');
+const {osInfo} = require('systeminformation');
 const providers = require('./providers.js');
 
 const DEBOUNCE_MS = 100;
@@ -34,7 +34,7 @@ class Insight {
 		this.trackingProvider = options.trackingProvider || 'google';
 		this.packageName = options.pkg.name;
 		this.packageVersion = options.pkg.version || 'undefined';
-		this.os = osName();
+		this.os = undefined;
 		this.nodeVersion = process.version;
 		this.appVersion = this.packageVersion;
 		this.config = options.config || new Conf({
@@ -46,6 +46,13 @@ class Insight {
 		this._queue = {};
 		this._permissionTimeout = 30;
 		this._debouncedSend = debounce(this._send, DEBOUNCE_MS, {leading: true});
+	}
+
+	async _appendOSData() {
+		const data = await osInfo();
+		this.os = process.platform === 'darwin'
+			? data.codename
+			: data.distro;
 	}
 
 	get optOut() {
@@ -98,7 +105,11 @@ class Insight {
 		};
 	}
 
-	_getRequestObj(...args) {
+	async _getRequestObj(...args) {
+		if (this.os === undefined) {
+			await this._appendOSData();
+		}
+
 		return providers[this.trackingProvider].apply(this, args);
 	}
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -14,12 +14,12 @@ process.on('message', message => {
 	Object.assign(q, message.queue);
 	config.delete('queue');
 
-	async.forEachSeries(Object.keys(q), (element, cb) => {
+	async.forEachSeries(Object.keys(q), async (element, cb) => {
 		const parts = element.split(' ');
 		const id = parts[0];
 		const payload = q[element];
 
-		request(insight._getRequestObj(id, payload), error => {
+		request(await insight._getRequestObj(id, payload), error => {
 			if (error) {
 				cb(error);
 				return;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
 		"conf": "^10.0.1",
 		"inquirer": "^6.3.1",
 		"lodash.debounce": "^4.0.8",
-		"os-name": "^4.0.1",
 		"request": "^2.88.0",
+		"systeminformation": "^5.17.4",
 		"tough-cookie": "^4.0.0",
 		"uuid": "^8.3.2"
 	},

--- a/test/providers-google-analytics.js
+++ b/test/providers-google-analytics.js
@@ -1,5 +1,5 @@
 import qs from 'querystring'; // eslint-disable-line unicorn/prefer-node-protocol, no-restricted-imports
-import osName from 'os-name';
+import {osInfo} from 'systeminformation';
 import test from 'ava';
 import Insight from '../lib/index.js';
 
@@ -25,20 +25,28 @@ const insight = new Insight({
 	packageVersion: ver,
 });
 
-test('form valid request for pageview', t => {
-	const requestObject = insight._getRequestObj(ts, pageviewPayload);
+const osName = async () => {
+	const osData = await osInfo();
+	return process.platform === 'darwin'
+		? osData.codename
+		: osData.distro;
+};
+
+test('form valid request for pageview', async t => {
+	const requestObject = await insight._getRequestObj(ts, pageviewPayload);
 	const _qs = qs.parse(requestObject.body);
 
 	t.is(_qs.tid, code);
 	t.is(Number(_qs.cid), Number(insight.clientId));
 	t.is(_qs.dp, pageviewPayload.path);
-	t.is(_qs.cd1, osName());
+
+	t.is(_qs.cd1, await osName());
 	t.is(_qs.cd2, process.version);
 	t.is(_qs.cd3, ver);
 });
 
-test('form valid request for eventTracking', t => {
-	const requestObject = insight._getRequestObj(ts, eventPayload);
+test('form valid request for eventTracking', async t => {
+	const requestObject = await insight._getRequestObj(ts, eventPayload);
 	const _qs = qs.parse(requestObject.body);
 
 	t.is(_qs.tid, code);
@@ -47,7 +55,7 @@ test('form valid request for eventTracking', t => {
 	t.is(_qs.ea, eventPayload.action);
 	t.is(_qs.el, eventPayload.label);
 	t.is(_qs.ev, eventPayload.value);
-	t.is(_qs.cd1, osName());
+	t.is(_qs.cd1, await osName());
 	t.is(_qs.cd2, process.version);
 	t.is(_qs.cd3, ver);
 });

--- a/test/providers-yandex-metrica.js
+++ b/test/providers-yandex-metrica.js
@@ -21,7 +21,7 @@ test('form valid request', async t => {
 	const request = require('request');
 
 	// Test querystrings
-	const requestObject = insight._getRequestObj(ts, pageviewPayload);
+	const requestObject = await insight._getRequestObj(ts, pageviewPayload);
 	const _qs = requestObject.qs;
 
 	t.is(_qs['page-url'], `http://${pkg}.insight/test/path?version=${ver}`);


### PR DESCRIPTION
resolves #83

## PR Changes

* Remove `os-name`
* Add `systeminformation`

## Summary

What is your opinion on replacing the `os-name` dependency with something else that can also get the operating system name?

This PR changes the dependency to `systeminformation` which can also get the name.

### The downside

* The dependency is bloated. The unpacked size is about **731.4 kB**.
* It has a ton of APIs for fetching various information that we most likely will never use. It is possible that we could provide in the future an ability for allowing users to configure Insight on what additional information they want to collect.
* It is also asynchronous.

### The plus side

* It appears to provide a more detailed name for Linux.  E.g. the distro name Debian, RedHat, FreeBSD, etc.
* Does not require any extra dependencies. Uses only what comes with node. E.g. os, child_process, etc
* Says to work with node >=8.

## Testing

In terms of testing, I only ran the unit tests and it passes.

# Final Thoughts

I believe it might be enough, but would like a review and if anyone can confirm that GA receives the data they expect.

If the bloating is an issue, maybe we could ask and  see if they could extract it as a module so we could selectively pick what we want.

`systeminformation` basically has similar information as `os-name` and similar mapping as `macos-release` library that `os-name` uses. The plus side is it contains a fallback value to ensure that it will not crash with future releases of macOS.